### PR TITLE
Fix support for <base> in rel-scraper

### DIFF
--- a/src/lib/rel-scraper.js
+++ b/src/lib/rel-scraper.js
@@ -8,8 +8,8 @@ export default function (htmlString, url) {
 
   if (baseEl) {
     const value = baseEl.getAttribute('href');
-    const url = new URL(value, url);
-    baseUrl = url.toString();
+    const urlObj = new URL(value, url);
+    baseUrl = urlObj.toString();
   }
 
   if (relEls.length) {


### PR DESCRIPTION
If you declare a variable with `let` or `const`, it *immediately* shadows any variable of the same name in the surrounding scope. This caused the `new URL()` call you can see in the diff to be called with arguments `(baseUrl, undefined)`, since there's no value for `url` yet, causing the constructor to throw and break the scraper.