### PR TITLE
Set default arrayFormat for qs.stringify to brackets

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -378,7 +378,7 @@ class Micropub {
           Accept: 'application/json, application/x-www-form-urlencoded',
         });
       } else if (type == 'form') {
-        request.body = qsStringify(object);
+        request.body = qsStringify(object, { arrayFormat: 'brackets' });
         request.headers = new Headers({
           Authorization: 'Bearer ' + this.options.token,
           'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',


### PR DESCRIPTION
When serializiing an object for the x-www-form-urlencoded format,
qs.stringify uses indices by default. This will encode

    { 'mp-syndicate-to': ['syn1','syn2'] }

to

    mp-syndicate-to[0]=syn1&mp-syndicate-to[1]=syn2

The Micropub spec says this format isn't supported. The 'brackets'
setting changes to serialization to:

    mp-syndicate-to[]=syn1&mp-syndicate-to[]=syn2

which is the supported format.